### PR TITLE
CHANGE make wlc_interface compatible with wlc-0.0.1

### DIFF
--- a/src/gram.c
+++ b/src/gram.c
@@ -225,62 +225,39 @@ int
 main (int argc, char **argv)
 {
   wlc_log_set_handler (logger);
-  /* *INDENT-OFF* */
-  static struct wlc_interface interface = {
-    .output = {
-      .created = output_created, // Done - Untested
-      .destroyed = output_destroyed, // Done - Untested
-      .focus = output_focus, // Done - Untested
-      .resolution = output_resolution, // Done - Untested
-      .render = {
-        .pre = output_render_pre, // Done - Untested
-        .post = output_render_post // Done - Untested
-      }
-    },
-    .view = {
-      .created = view_created, // Done
-      .destroyed = view_destroyed, // Done - Untested
-      .focus = view_focus, // Done - Untested
-      .move_to_output = view_move_to_output, // Done - Untested
-      /* punting on these for the moment */
-      .request = {
-        .geometry = view_request_geometry,
-      /*   .state = view_request_state, */
-      /*   .move = view_request_move, */
-      /*   .resive = view_request_resize, */
-      },
-      .render = {
-        .pre = view_render_pre, // Done - Untested
-        .post = view_render_post // Done - Untested
-      }
-    },
-    .keyboard = {
-      .key = keyboard_key, // Done - should add keyup
-    },
-    .pointer = {
-      /* the .button and .scroll events should be tied into the key
-         system e.g. (kbd "M-Mouse1"), (kbd "M-ScrollUp") */
-      /* .button = pointer_button,  */
-      /* .scroll = pointer_scroll, */
-      .motion = pointer_motion, // Done - untested
-    },
-    /* this .touch should also be tied into the key system */
-    /* .touch = { */
-    /*   .touch = touch_touch, */
-    /* }, */
-    .compositor = {
-      .ready = compositor_ready,
-      .terminate = compositor_terminate,
-    },
-    /* Experimental -- Don't see need for at the moment */
-    /* .input = { */
-    /*   .created = input_created, */
-    /*   .destroyed = input_destroyed, */
-    /* } */
-  };
-  /* *INDENT-ON* */
 
-  if (!wlc_init (&interface, argc, argv))
+  wlc_set_output_created_cb (output_created); // Done - Untested
+  wlc_set_output_destroyed_cb (output_destroyed); // Done - Untested
+  wlc_set_output_focus_cb (output_focus); // Done - Untested
+  wlc_set_output_resolution_cb (output_resolution); // Done - Untested
+  wlc_set_output_render_pre_cb (output_render_pre); // Done - Untested
+  wlc_set_output_render_post_cb (output_render_post); // Done - Untested
+  wlc_set_view_created_cb (view_created); // Done
+  wlc_set_view_destroyed_cb (view_destroyed); // Done - Untested
+  wlc_set_view_focus_cb (view_focus); // Done - Untested
+  wlc_set_view_move_to_output_cb (view_move_to_output); // Done - Untested
+  /* punting on these for the moment */
+  wlc_set_view_request_geometry_cb (view_request_geometry);
+  /* wlc_set_state_cb (view_request_state); */
+  /* wlc_set_move_cb (view_request_move); */
+  /* wlc_set_resize_cb (view_request_resize); */
+  wlc_set_view_render_pre_cb (view_render_pre); // Done - Untested
+  wlc_set_view_render_post_cb (view_render_post); // Done - Untested
+  wlc_set_keyboard_key_cb (keyboard_key); // Done - should add keyup
+  /* the pointer_button and pointer_scroll events should be tied into the key
+     system e.g. (kbd "M-Mouse1") (kbd "M-ScrollUp") */
+  /* wlc_set_pointer_button_cb (pointer_button);  */
+  /* wlc_set_pointer_scroll_cb (pointer_scroll); */
+  wlc_set_pointer_motion_cb (pointer_motion); // Done - untested
+  /* this .touch should also be tied into the key system */
+  /* wlc_set_touch_touch_cb (touch_touch); */
+  wlc_set_compositor_ready_cb (compositor_ready);
+  wlc_set_compositor_terminate_cb (compositor_terminate);
+  /* Experimental -- Don't see need for at the moment */
+  /* wlc_set_input_created_cb (input_created); */
+  /* wlc_set_input_destroyed_cb (input_destroyed); */
+
+  if (!wlc_init2 ())
     return EXIT_FAILURE;
 
   char *init_file = get_init_file (argc, argv);
@@ -297,7 +274,5 @@ main (int argc, char **argv)
   }
 
   wlc_run ();
-
-
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
[As of wlc version 0.0.1](https://github.com/Cloudef/wlc/commit/669eea003ded706aad61c47068c4b848fe24964e) callback functions are used to construct the interface. 

This change uses the callback functions instead of constructing the interface struct manually.

Note that you'll have to update wlc to 0.0.1 for this change to work.
